### PR TITLE
Registro de usuarios mediante formulario y envio de datos de registro a Usuarios Fresenius mediante api

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -113,6 +113,105 @@
   transition:ease all 0.4s;
 }
 
+.ui-dialog{
+  width: 580px!important;
+  /*height: 869px!important;*/
+}
+.ui-dialog:not(.ui-dialog-off-canvas){
+  border-radius: 0 none!important;
+}
+.layout-container{
+  margin-bottom: 4rem;
+}
+#drupal-modal{
+  /*height: 100%!important;*/
+  /*max-height: 100%!important;*/
+}
+.ui-widget-overlay.ui-front{
+  background-color: rgba(0,0,0,0.8);
+}
+body.gin-login .user-form-page__page-title {
+  font-size: 2rem!important;
+  margin-top: 0!important;
+  margin-bottom: 1rem;
+  width: 100%;
+  max-width: 100%;
+  text-overflow: unset;
+  white-space: normal;
+  text-align: center;
+}
+.ui-dialog .ui-dialog-titlebar-close{
+  position: fixed!important;
+  right: 40px !important;
+  top: 30px !important;
+  background-color: white !important;
+  padding: 0 !important;
+  width: 40px !important;
+  height: 40px !important;
+  display: block !important;
+  border-radius: 30px !important;
+  background-size: 60% !important;
+  box-shadow: 0 10px 25px rgba(0,0,0,0.2);
+  opacity: 0.8;
+  transition: ease all 0.4s;
+}
+.ui-dialog .ui-dialog-titlebar-close .ui-icon-closethick{
+  background-size: contain;
+  background:transparent url(/modules/custom/tienda_autologin/assets/icons/x-sin-circulo.svg) no-repeat center center!important;
+  position: absolute;
+  right: 20px;
+  top: 20px;
+  margin: 0;
+  padding: 0;
+  z-index: 99;
+  color: white;
+  opacity: 1;
+  font-weight: 400;
+  font-size: 0;
+  min-width: 30px;
+  height: 30px;
+  width: 30px;
+  border: none;
+  cursor: pointer;
+}
+.ui-dialog .ui-dialog-titlebar{
+  background: #fff!important;
+  border-radius: 0 none!important;
+}
+.ui-dialog .ui-dialog-title{
+  display: none!important;
+}
+.ui-dialog .ui-dialog-buttonpane .ui-dialog-buttonset{
+  float: left;
+}
+.ui-dialog .description{
+  margin-top: 0.375rem;
+  margin-bottom: 0.375rem;
+  color: #55565b;
+  font-size: 0.79rem;
+  line-height: 1.0625rem;
+}
+
+.ui-dialog .ui-dialog-buttonpane .ui-dialog-buttonset button{
+  padding: calc(1rem - 2px) calc(1.5rem - 2px);
+  border: 2px solid #3f3f3f !important;
+  border-top-color: rgb(63, 63, 63);
+  border-right-color: rgb(63, 63, 63);
+  border-bottom-color: rgb(63, 63, 63);
+  border-left-color: rgb(63, 63, 63);
+  border-radius: 6px;
+  -webkit-box-shadow: 0 1px 2px var(--colorGinPrimaryLight);
+  box-shadow: 0 1px 2px var(--colorGinPrimaryLight);
+  color: #3f3f3f !important;
+  background-color: white !important;
+}
+.ui-dialog .ui-dialog-buttonpane .ui-dialog-buttonset button:hover{
+  background-color: #3f3f3f !important;
+  color: white !important;
+  border-color: #3f3f3f !important;
+}
+
+
 @media (min-width: 576px) {
   .modal-custom-style-autologin .E-espacio-cabecera > button.close {
     top: 15px !important;

--- a/js/tienda_autologin.js
+++ b/js/tienda_autologin.js
@@ -31,7 +31,7 @@
         </div>`);
         $('#modal-message-pass-form-auto-login').show();
         $('#modal-message-pass-form-auto-login').addClass('modal-password-show show');
-        
+
         $("#modal-message-pass-form-auto-login").find('.close').once('modal-load-pass-user-form-auto-login-close').click(function () {
           $('#modal-message-pass-form-auto-login').hide();
 
@@ -71,8 +71,8 @@
           $('#modal-load-edit-user-form-auto-login').find('h3').text("Editar Usuario");
 	      $('#modal-load-edit-user-form-auto-login').find("#load-edit-user-form-content").prepend(`<iframe id="iframe_set_password_form" title="Editar usuario" width="580" height="${height}" src="${$url_site}" frameBorder="0"></iframe>`);
         });
-        
-        $("#modal-load-edit-user-form-auto-login").find('.close').once('modal-load-edit-user-form-auto-login-close').click(function () {        
+
+        $("#modal-load-edit-user-form-auto-login").find('.close').once('modal-load-edit-user-form-auto-login-close').click(function () {
           $(this).parents('.modal').find('iframe').remove();
           $('#modal-load-edit-user-form-auto-login').hide();
 
@@ -86,7 +86,7 @@
       $("#modal-load-register-form-auto-login .close").click(function () {
         $(this).parents('.modal').find('iframe').remove();
         $('#modal-load-register-form-auto-login').hide();
-        
+
         if ($('#modal-load-register-form-auto-login').hasClass('modal-reset-password-show')) {
           $('#modal-load-register-form-auto-login').removeClass('modal-reset-password-show show');
         }
@@ -133,10 +133,49 @@
           let $url_site = `${$url_host}/redirect/externalsite?redirect=${$url_redirect}&autologin=true&op=register&redirect_external=${$redirect_host_external}`;
 
           let height = $(window).height();
-	      $('#modal-load-register-form-auto-login').find("#load-register-form-content").prepend(`<iframe id="iframe_register_form" title="Registro de usuario" width="580" height="${height}" src="${$url_site}" frameBorder="0"></iframe>`);
-
+	       $('#modal-load-register-form-auto-login').find("#load-register-form-content").prepend(`<iframe id="iframe_register_form" title="Registro de usuario" width="580" height="${height}" src="${$url_site}" frameBorder="0"></iframe>`);
         });
       }
     }
   };
+
+
 })(jQuery, Drupal, drupalSettings);
+
+
+
+(function ($, Drupal, drupalSettings) {
+  Drupal.behaviors.tienda_autologin_modal = {
+    attach: function (context, settings) {
+      $('#edit-register-button').remove();
+      $('#modal-register-form').once().click(function (e) {
+        e.preventDefault();
+        $url = $(this).attr('link');
+        $tipo = $(this).attr('tipo');
+
+        if ($tipo == undefined) {
+          $class = 'modal-class';
+        }
+        else {
+          $class = $tipo;
+        }
+
+        var ajaxSettings = {
+          url: $url,
+          dialogType: 'modal',
+          dialogOptions: {
+            dialogClass: $class,
+            width: 580,
+            height: 869,
+            multiple: true,
+          }
+        };
+        var myAjaxObject = Drupal.ajax(ajaxSettings);
+        myAjaxObject.execute();
+      });
+    }
+  }
+})(jQuery, Drupal);
+
+
+

--- a/src/Form/TiendaRegistroUsuarioForm.php
+++ b/src/Form/TiendaRegistroUsuarioForm.php
@@ -1,0 +1,275 @@
+<?php
+namespace Drupal\tienda_autologin\Form;
+
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Ajax\AlertCommand;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Markup;
+use Drupal\taxonomy\Entity\Term;
+use Exception;
+use JetBrains\PhpStorm\NoReturn;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+/**
+ * Configure example settings for this site.
+ */
+class TiendaRegistroUsuarioForm extends FormBase {
+
+
+  public function getFormId() {
+    // TODO: Implement getFormId() method.
+    return 'tienda_autologin_registro_usuario';
+  }
+
+  function buildForm(array $form, FormStateInterface $form_state) {
+    $form['#prefix'] = '<div id="my-form-wrapper">';
+    $form['#suffix'] = '</div>';
+
+    $form['field_nombre'] =  array(
+      '#type' => 'textfield',
+      '#title' => $this->t('Nombre'),
+      '#title_display' => FALSE,
+      '#attributes' => [
+        'placeholder' => 'Nombre*',
+        'class' => ['form-element']
+      ],
+      '#required' => TRUE
+    );
+    $form['field_apellidos'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Apellidos'),
+      '#title_display' => FALSE,
+      '#attributes' => [
+        'placeholder' => 'Apellidos*',
+        'class' => ['form-element']
+      ],
+      '#required' => TRUE
+    ];
+    $options = $this->_getTerminos('genero');
+    $form['field_genero'] = [
+      '#type' => 'select',
+      '#title' => "Genero",
+      '#title_display' => FALSE,
+      '#options' => $options,
+      '#empty_option' => 'Genero*',
+      '#attributes' => [
+        'class' => ['form-element', 'form-element--type-select']
+      ],
+      '#required' => TRUE
+    ];
+    $form['field_hospital'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Hospital'),
+      '#title_display' => FALSE,
+      '#attributes' => [
+        'placeholder' => 'Hospital*',
+        'class' => ['form-element']
+      ],
+      '#required' => TRUE
+    ];
+    $options = $this->_getTerminos('especialidad');
+    $form['field_especialidad'] = [
+      '#type' => 'select',
+      '#title' => "Especialidad",
+      '#title_display' => FALSE,
+      '#options' => $options,
+      '#empty_option' => 'Especialidad*',
+      '#attributes' => [
+        'class' => ['form-element', 'form-element--type-select']
+      ],
+      '#required' => TRUE
+    ];
+    $form['field_numero_de_colegiado'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Número de colegiado'),
+      '#title_display' => FALSE,
+      '#attributes' => [
+        'placeholder' => 'Número de colegiado*',
+        'class' => ['form-element']
+      ],
+      '#states' => [
+        'invisible' => [
+          ':input[name="field_no_tengo_numero_de_colegia"]' => ['checked' => TRUE],
+        ],
+        '#required' => TRUE
+      ],
+    ];
+    $form['field_no_tengo_numero_de_colegia'] = [
+      '#type' => 'checkbox',
+      '#default_value' => false,
+      '#description' => $this->t('No tengo número de colegiado'),
+//      '#ajax' => [
+//        'callback' => '::toggleTextField',
+//        'wrapper' => 'edit-textfield-wrapper',
+//      ],
+    ];
+    $form['field_pais'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('País'),
+      '#title_display' => FALSE,
+      '#attributes' => [
+        'placeholder' => 'País*',
+        'class' => ['form-element']
+      ],
+      '#required' => TRUE
+    ];
+    $form['field_provincia'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Provincia'),
+      '#title_display' => FALSE,
+      '#attributes' => [
+        'placeholder' => 'Provincia*',
+        'class' => ['form-element']
+      ],
+      '#required' => TRUE
+    ];
+    $form['field_telefono'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Teléfono'),
+      '#title_display' => FALSE,
+      '#attributes' => [
+        'placeholder' => 'Teléfono',
+        'class' => ['form-element']
+      ]
+    ];
+    $form['field_email'] = [
+      '#type' => 'email',
+      '#title' => $this->t('Correo electrónico'),
+      '#title_display' => FALSE,
+      '#attributes' => [
+        'placeholder' => 'Correo electrónico*',
+        'class' => ['form-element']
+      ],
+      '#required' => TRUE
+    ];
+    $form['field_password'] = [
+      '#type' => 'password',
+      '#title' => $this->t('Contraseña'),
+      '#title_display' => FALSE,
+      '#attributes' => [
+        'placeholder' => 'Contraseña*',
+        'class' => ['form-element']
+      ],
+      '#required' => TRUE
+    ];
+    $form['field_acepto_la_politica_de_priv'] = [
+      '#type' => 'checkbox',
+      '#default_value' => 0,
+      '#attributes' => [
+        'class' => ['form-item__description']
+      ],
+      '#description' => $this->t('Consiento el tratamiento de mis datos. Fresenius SE, tratará sus datos con la finalidad de gestionar su solicitud de registro. Tiene derecho a acceder, rectificar y suprimir los datos , así como otros derechos, como se explica en la ') . Markup::create('<a href="/politica-de-privacidad">política de privacidad</a>')
+    ];
+    $form['actions'] = [
+      '#type' => 'actions',
+    ];
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => 'Crear nueva cuenta',
+      '#attributes' => ['id' => 'submit_crear', 'class' => ['register-button', 'button--secondary']],
+    ];
+
+    $form['#theme'] = 'crear_tienda_autologin_form_template';
+
+    return $form;
+  }
+
+  function submitForm(array &$form, FormStateInterface $form_state) {
+//    parent::submitForm($form, $form_state); // TODO: Change the autogenerated stub
+    $values = $form_state->getValues();
+    $genero_tid = $this->_getTid('genero', $values['field_genero']); // ej 2
+    $especialidad_tid = $this->_getTid('especialidad', $values['field_especialidad']);
+
+    $bool_colegiado = 'false';
+    if($values['field_no_tengo_numero_de_colegia']) {
+      if($values['field_no_tengo_numero_de_colegia'] == 1) {
+        $bool_colegiado = 'true';
+      }
+    }
+
+    $user_data = [
+      'mail' => $values['field_email'],
+      'pass' => $values['field_password'],
+      'nombre' => $values['field_nombre'] ?? NULL,
+      'apellidos' => $values['field_apellidos'] ?? NULL,
+      'hospital' => $values['field_hospital'],
+      'numero_colegiado' => $values['field_numero_de_colegiado'] ?? NULL,
+      'bool_numero_colegiado' => $bool_colegiado,
+      'pais' => $values['field_pais'],
+      'provincia' => $values['field_provincia'],
+      'telefono' => $values['field_telefono'] ?? NULL,
+      'bool_tratamiento_datos' => 'true',//$values['field_tratamiento_de_datos'][0]['value'],
+      'especialidad' => $especialidad_tid,
+      'genero' => $genero_tid,
+    ];
+    try {
+      //Calling Creation service
+      $createNutritalksUSer = \Drupal::service('tienda_autologin.user_register');
+      $createNutritalksUSer = $createNutritalksUSer->post($user_data);
+      if($createNutritalksUSer == 200 ) {
+        \Drupal::logger('enviar_registro_usuario')->notice($createNutritalksUSer);
+
+        \Drupal::messenger()->addMessage('El usuario ha sido creado correctamente.');
+        $url = '/usuario/acceso';
+        $response = new RedirectResponse($url);
+        $response->send();
+        exit();
+      }else {
+        \Drupal::messenger()->addError('El usuario no ha sido creado.');
+        $url = '/usuario/acceso';
+        $response = new RedirectResponse($url);
+        $response->send();
+        exit();
+      }
+    } catch (Exception $e) {
+      \Drupal::logger('enviar_registro_usuario')->error($e->getMessage());
+      \Drupal::messenger()->addError('El usuario no ha sido creado.');
+      $url = '/usuario/acceso';
+      $response = new RedirectResponse($url);
+      $response->send();
+      exit();
+    }
+  }
+
+  private function _getTerminos($vid): array
+  {
+    $terms = \Drupal::entityQuery('taxonomy_term')
+      ->condition('status', 1)
+      ->condition('vid', $vid)
+      ->execute();
+
+    $terminos = [];
+    if (sizeof($terms) > 0) {
+      foreach ($terms as $_term) {
+        $term = Term::load($_term);
+
+        if (!is_null($term)) {
+          $terminos[$term->id()] = $term->getName();
+
+        }
+      }
+    }
+
+    return $terminos;
+  }
+  function _getTid($vid, $real_tid) {
+    //Get Tid
+    $custom_field = 'field_api_id';
+    $tid = 0;
+
+    $terms =\Drupal::entityTypeManager()
+      ->getStorage('taxonomy_term')
+      ->loadTree($vid, 0, 2, TRUE);
+    foreach ($terms as $term) {
+      foreach ($term->getFields(false) as $field) {
+        if ($field->getName() == $custom_field && $term->get('tid')->value == $real_tid) {
+          $tid = $term->get('field_api_id')->value;
+        }
+      }
+    }
+
+    return $tid;
+  }
+
+}

--- a/src/Services/UsersFreseniusService.php
+++ b/src/Services/UsersFreseniusService.php
@@ -7,8 +7,7 @@ class UsersFreseniusService {
         if(!empty($data)) {
             //Connection info:
           $prod_endpoint = 'https://www.usuariosfresenius.com/api/v1/user/register';
-//          $dev_endpoint = 'https://usuariosfresenius.creacionwebprofesional.com/api/v1/user/register';
-          $dev_endpoint = 'https://usuariosfresenius.ddev.site/api/v1/user/register';
+          $dev_endpoint = 'https://usuariosfresenius.creacionwebprofesional.com/api/v1/user/register';
 
             //Prepare data
             $body = json_encode($data);

--- a/src/Services/UsersFreseniusService.php
+++ b/src/Services/UsersFreseniusService.php
@@ -1,0 +1,37 @@
+<?php
+namespace Drupal\tienda_autologin\Services;
+
+class UsersFreseniusService {
+
+    public function post(array $data) {
+        if(!empty($data)) {
+            //Connection info:
+          $prod_endpoint = 'https://www.usuariosfresenius.com/api/v1/user/register';
+//          $dev_endpoint = 'https://usuariosfresenius.creacionwebprofesional.com/api/v1/user/register';
+          $dev_endpoint = 'https://usuariosfresenius.ddev.site/api/v1/user/register';
+
+            //Prepare data
+            $body = json_encode($data);
+          $token_jwt = 'vhQjw7CaceTMhfGGpYI+tGKXBI7BSc926QzKnhMdlUr/XhL+3RDABf6XeNRbQ2QsyiKljXJbdKjwa/6smmVF2w==';
+
+            $client = \Drupal::httpClient();
+            $headers = [
+                'Authorization: Bearer ' . $token_jwt,
+                'Content-Type' => 'application/json'
+            ];
+                      $response = $client->post($dev_endpoint, [
+                'body' => $body,
+                'headers' => $headers
+            ]);
+
+
+            $code = $response->getStatusCode();
+
+
+            return $code;
+
+        }else {
+            return "Empty data.";
+        }
+    }
+}

--- a/templates/crear-tienda-autologin-form.html.twig
+++ b/templates/crear-tienda-autologin-form.html.twig
@@ -1,0 +1,16 @@
+{{ form.form_build_id }}
+{{ form.form_token }}
+{{ form.form_id }}
+
+<header class="content-header clearfix">
+  <div class="layout-container">
+    <a href="/" class="toolbar-logo" data-drupal-link-system-path="<front>">
+      <img src="/themes/custom/frontend/assets/gin/logo_gin_login.svg" alt="MicroServicio Fresenius Kabi" class="toolbar-icon-home">
+    </a>
+  </div>
+</header>
+<h1 class="page-title user-form-page__page-title">Crear nueva cuenta</h1>
+{{ form }}
+
+
+

--- a/tienda_autologin.module
+++ b/tienda_autologin.module
@@ -14,6 +14,18 @@ use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\Core\Render\Markup;
 
 /**
+ * Implements hook_theme().
+ */
+function tienda_autologin_theme($existing, $type, $theme, $path) {
+  return [
+    'crear_tienda_autologin_form_template' => [
+      'template' => 'crear-tienda-autologin-form',
+      'render element' => 'form'
+    ]
+  ];
+}
+
+/**
  * hook_preprocess_page
  */
 function tienda_autologin_preprocess(&$variables, $hook) {
@@ -36,6 +48,8 @@ function tienda_autologin_preprocess(&$variables, $hook) {
   $variables['#attached']['drupalSettings']['tienda_autologin']['redirect_host'] = $config->get('backend_url');
   $variables['#attached']['drupalSettings']['tienda_autologin']['redirect_host_external'] = $url_host;
 
+  $variables['#attached']['library'][] = 'core/drupal.ajax';
+
 }
 
 /**
@@ -46,20 +60,12 @@ function tienda_autologin_form_alter(&$form, FormStateInterface $form_state, $fo
 
   switch ($form_id) {
     case 'user_login_form':
-      $form['more-links']['#suffix'] = Markup::create('<div id="load-register-form-auto-login">
-        <div class="modales modal fade modal-custom-style-autologin" tabindex="-1" id="modal-load-register-form-auto-login" aria-hidden="true">
-          <div class="modal-dialog">
-            <div class="modal-content">
-              <section class="E-espacio-cabecera G-fondo--blanco">
-                <button type="button" class="close" data-bs-dismiss="modal" aria-label="Close"></button>
-                <div class="G-max--700 G-margen--xs" style="padding: 0">
-                  <div id="load-register-form-content"></div>
-                </div>
-              </section>
-            </div>
-          </div>
-        </div>
-      </div>');
+
+      $form_reg = \Drupal::formBuilder()->getForm('Drupal\tienda_autologin\Form\TiendaRegistroUsuarioForm');
+      $form['more-links']['register_button']['#suffix'] = Markup::create('<button type="button" link="/tienda_autologin/get-user-register-form" id="modal-register-form" class="register-button button button--secondary">
+        Crear nueva cuenta
+        </button>
+');
 
       $config =  \Drupal::config('tienda_autologin.configuration');
       if (@in_array('::validateFinal', $form['#validate'])) {
@@ -305,7 +311,7 @@ function tienda_autologin_user_logout(AccountInterface $account) {
         throw $e;
       }
       $response = $e->getResponse();
-  
+
       $data = Json::Decode($response->getBody()->getContents());
       $messenger = \Drupal::Messenger();
       $messenger->addMessage($data["message"],$messenger::TYPE_ERROR,true);

--- a/tienda_autologin.routing.yml
+++ b/tienda_autologin.routing.yml
@@ -16,3 +16,12 @@ tienda_autologin.redirectite:
     _permission: 'access content'
   options:
     no_cache: 'TRUE'
+
+
+tienda_autologin.get_user_register_form:
+  path: '/tienda_autologin/get-user-register-form'
+  defaults:
+    _form: '\Drupal\tienda_autologin\Form\TiendaRegistroUsuarioForm'
+    _title: 'Crear nueva cuenta'
+  requirements:
+    _permission: 'access content'

--- a/tienda_autologin.services.yml
+++ b/tienda_autologin.services.yml
@@ -1,7 +1,7 @@
 services:
   tienda_autologin.externalauth:
     class: Drupal\tienda_autologin\ExternalAuth
-    arguments: ['@entity_type.manager', '@logger.channel.tienda_autologin', '@event_dispatcher']  
+    arguments: ['@entity_type.manager', '@logger.channel.tienda_autologin', '@event_dispatcher']
   logger.channel.tienda_autologin:
     parent: logger.channel_base
     arguments: ['tienda_autologin']
@@ -9,3 +9,7 @@ services:
     class: Drupal\tienda_autologin\EventSubscriber\TiendaAutoLoginSubscriber
     tags:
       - {name: event_subscriber}
+  tienda_autologin.user_register:
+    class: Drupal\tienda_autologin\Services\UsersFreseniusService
+    tags:
+      - { name: tienda_autologin_user_registro_service }


### PR DESCRIPTION

- Se implementó el Registro de usuarios mediante formulario.
- Se envían los datos de registro a Usuarios Fresenius mediante api.

*** Revisar el token de jwt_auth en el sitio Fresenius para poder hacer autorizacion de la llamada al endpoint de registro (https://usuariosfresenius.creacionwebprofesional.com/api/v1/user/register)